### PR TITLE
Update with upstream changes in 0.5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,17 @@ matrix:
       rvm: 2.5.3
       env: DB=postgresql DB_USERNAME=postgres DB_PASSWORD=""
       services: postgresql
+    - gemfile: spec/gemfiles/rails_6_1.gemfile
+      rvm: 2.5.3
+      env: DB=sqlite3
+    - gemfile: spec/gemfiles/rails_6_1.gemfile
+      rvm: 2.5.3
+      env: DB=mysql2 DB_USERNAME=root DB_PASSWORD=""
+      services: mysql
+    - gemfile: spec/gemfiles/rails_6_1.gemfile
+      rvm: 2.5.3
+      env: DB=postgresql DB_USERNAME=postgres DB_PASSWORD=""
+      services: postgresql
 env:
   global:
   - TRAVIS=1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## 0.5.3
+
+* Rails 7.1 now supported.
+
 ## 0.5.2
 
 * Ruby 3.0 now supported.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## 0.5.2
+
+* Ruby 3.0 now supported.
+
 ## 0.5.1
 
 * Rails 6.1 now supported.
@@ -23,7 +27,7 @@
 
 ## 0.3.4
 
-* The `before` and `after` methods now accept a boolean argument that indicates 
+* The `before` and `after` methods now accept a boolean argument that indicates
   whether the relation should exclude the given point or not.
   By default the given point is excluded, if you want to include it,
   use `before(false)` / `after(false)`.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+## 0.5.1
+
+* Rails 6.1 now supported.
 ## 0.5.0
 
 * Rails 6 now supported.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## 0.5.4
+
+* Rails 7.2 now supported
+
 ## 0.5.3
 
 * Rails 7.1 now supported.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ## 0.5.2
 
 * Ruby 3.0 now supported.
+* Rails 7.0 now supported.
 
 ## 0.5.1
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,5 @@
 
 source 'https://rubygems.org'
 
-eval_gemfile 'spec/gemfiles/rails_7_1.gemfile'
+eval_gemfile 'spec/gemfiles/rails_7_2.gemfile'
 eval_gemfile 'rubocop.gemfile'

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,5 @@
 
 source 'https://rubygems.org'
 
-eval_gemfile 'spec/gemfiles/rails_7_0.gemfile'
+eval_gemfile 'spec/gemfiles/rails_7_1.gemfile'
 eval_gemfile 'rubocop.gemfile'

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,5 @@
 
 source 'https://rubygems.org'
 
-eval_gemfile 'spec/gemfiles/rails_6_1.gemfile'
+eval_gemfile 'spec/gemfiles/rails_7_0.gemfile'
 eval_gemfile 'rubocop.gemfile'

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,5 @@
 
 source 'https://rubygems.org'
 
-eval_gemfile 'spec/gemfiles/rails_6_0.gemfile'
+eval_gemfile 'spec/gemfiles/rails_6_1.gemfile'
 eval_gemfile 'rubocop.gemfile'

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This gem finds the next or previous record(s) relative to the current one effici
 Add to Gemfile:
 
 ```ruby
-gem 'order_query', '~> 0.5.3'
+gem 'order_query', '~> 0.5.4'
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This gem finds the next or previous record(s) relative to the current one effici
 Add to Gemfile:
 
 ```ruby
-gem 'order_query', '~> 0.5.2'
+gem 'order_query', '~> 0.5.3'
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This gem finds the next or previous record(s) relative to the current one effici
 Add to Gemfile:
 
 ```ruby
-gem 'order_query', '~> 0.5.0'
+gem 'order_query', '~> 0.5.1'
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This gem finds the next or previous record(s) relative to the current one effici
 Add to Gemfile:
 
 ```ruby
-gem 'order_query', '~> 0.5.1'
+gem 'order_query', '~> 0.5.2'
 ```
 
 ## Usage

--- a/lib/order_query/nulls_direction.rb
+++ b/lib/order_query/nulls_direction.rb
@@ -32,12 +32,21 @@ module OrderQuery
     # @return [:first, :last] the default nulls order, based on the given
     #   scope's connection adapter name.
     def default(scope, dir)
-      case scope.connection_config[:adapter]
+      case connection_adapter(scope)
       when /mysql|maria|sqlite|sqlserver/i
         (dir == :asc ? :first : :last)
       else
         # Oracle, Postgres
         (dir == :asc ? :last : :first)
+      end
+    end
+
+    def connection_adapter(scope)
+      if scope.respond_to?(:connection_db_config)
+        # Rails >= 6.1.0
+        scope.connection_db_config.adapter
+      else
+        scope.connection_config[:adapter]
       end
     end
   end

--- a/lib/order_query/point.rb
+++ b/lib/order_query/point.rb
@@ -68,14 +68,14 @@ module OrderQuery
       v = record.send(column.name)
       if v.nil? && !column.nullable?
         fail Errors::NonNullableColumnIsNullError,
-             "Column #{column.inspect} is NULL on record #{@record.inspect}. "\
+             "Column #{column.inspect} is NULL on record #{@record.full_inspect}. "\
              'Set the `nulls` option to :first or :last.'
       end
       v
     end
 
     def inspect
-      "#<OrderQuery::Point @record=#{@record.inspect} @space=#{@space.inspect}>"
+      "#<OrderQuery::Point @record=#{@record.full_inspect} @space=#{@space.inspect}>"
     end
 
     protected

--- a/lib/order_query/point.rb
+++ b/lib/order_query/point.rb
@@ -68,14 +68,14 @@ module OrderQuery
       v = record.send(column.name)
       if v.nil? && !column.nullable?
         fail Errors::NonNullableColumnIsNullError,
-             "Column #{column.inspect} is NULL on record #{@record.full_inspect}. "\
+             "Column #{column.inspect} is NULL on record #{@record.send(inspect_method)}. "\
              'Set the `nulls` option to :first or :last.'
       end
       v
     end
 
     def inspect
-      "#<OrderQuery::Point @record=#{@record.full_inspect} @space=#{@space.inspect}>"
+      "#<OrderQuery::Point @record=#{@record.send(inspect_method)} @space=#{@space.inspect}>"
     end
 
     protected
@@ -84,6 +84,12 @@ module OrderQuery
     # @return [ActiveRecord::Base, nil] rec unless rec == @record
     def unless_record_eq(rec)
       rec unless rec == @record
+    end
+
+    private
+    def inspect_method
+      Gem::Version.new(ActiveRecord::VERSION::STRING) >= Gem::Version.new("7.2.0") ? :full_inspect
+                                                                                   : :inspect
     end
   end
 end

--- a/lib/order_query/space.rb
+++ b/lib/order_query/space.rb
@@ -15,7 +15,7 @@ module OrderQuery
     def initialize(base_scope, order_spec)
       @base_scope = base_scope
       @columns = order_spec.map do |cond_spec|
-        Column.new(base_scope, *cond_spec)
+        build_column(base_scope, cond_spec)
       end
       # add primary key if columns are not unique
       unless @columns.last.unique?
@@ -57,6 +57,14 @@ module OrderQuery
     def inspect
       "#<OrderQuery::Space @columns=#{@columns.inspect} "\
       "@base_scope=#{@base_scope.inspect}>"
+    end
+
+    private
+
+    def build_column(base_scope, cond_spec)
+      column_spec = cond_spec.last.is_a?(Hash) ? cond_spec : cond_spec.push({})
+      attr_name, *vals_and_or_dir, options = column_spec
+      Column.new(base_scope, attr_name, *vals_and_or_dir, **options)
     end
   end
 end

--- a/lib/order_query/space.rb
+++ b/lib/order_query/space.rb
@@ -14,7 +14,8 @@ module OrderQuery
     # @see Column#initialize for the order_spec element format.
     def initialize(base_scope, order_spec)
       @base_scope = base_scope
-      @columns = order_spec.map do |cond_spec|
+      @columns = order_spec.map(&:clone)
+      @columns.map! do |cond_spec|
         build_column(base_scope, cond_spec)
       end
       # add primary key if columns are not unique

--- a/lib/order_query/version.rb
+++ b/lib/order_query/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OrderQuery
-  VERSION = '0.5.3'
+  VERSION = '0.5.4'
 end

--- a/lib/order_query/version.rb
+++ b/lib/order_query/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OrderQuery
-  VERSION = '0.5.2'
+  VERSION = '0.5.3'
 end

--- a/lib/order_query/version.rb
+++ b/lib/order_query/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OrderQuery
-  VERSION = '0.5.1'
+  VERSION = '0.5.2'
 end

--- a/lib/order_query/version.rb
+++ b/lib/order_query/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OrderQuery
-  VERSION = '0.5.0'
+  VERSION = '0.5.1'
 end

--- a/order_query.gemspec
+++ b/order_query.gemspec
@@ -23,8 +23,8 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.3.0'
 
-  s.add_dependency 'activerecord', '>= 5.0', '< 7.1'
-  s.add_dependency 'activesupport', '>= 5.0', '< 7.1'
+  s.add_dependency 'activerecord', '>= 5.0', '< 7.2'
+  s.add_dependency 'activesupport', '>= 5.0', '< 7.2'
   s.add_development_dependency 'rake', '~> 13.0'
   s.add_development_dependency 'rspec', '~> 3.4'
   s.add_development_dependency 'simplecov'

--- a/order_query.gemspec
+++ b/order_query.gemspec
@@ -23,8 +23,8 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.3.0'
 
-  s.add_dependency 'activerecord', '>= 5.0', '< 7.2'
-  s.add_dependency 'activesupport', '>= 5.0', '< 7.2'
+  s.add_dependency 'activerecord', '>= 5.0', '< 7.3'
+  s.add_dependency 'activesupport', '>= 5.0', '< 7.3'
   s.add_development_dependency 'rake', '~> 13.0'
   s.add_development_dependency 'rspec', '~> 3.4'
   s.add_development_dependency 'simplecov'

--- a/order_query.gemspec
+++ b/order_query.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activerecord', '>= 5.0', '< 7.0'
   s.add_dependency 'activesupport', '>= 5.0', '< 7.0'
-  s.add_development_dependency 'rake', '~> 10.2'
+  s.add_development_dependency 'rake', '~> 13.0'
   s.add_development_dependency 'rspec', '~> 3.4'
   s.add_development_dependency 'simplecov'
 end

--- a/order_query.gemspec
+++ b/order_query.gemspec
@@ -23,8 +23,8 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.3.0'
 
-  s.add_dependency 'activerecord', '>= 5.0', '< 7.0'
-  s.add_dependency 'activesupport', '>= 5.0', '< 7.0'
+  s.add_dependency 'activerecord', '>= 5.0', '< 7.1'
+  s.add_dependency 'activesupport', '>= 5.0', '< 7.1'
   s.add_development_dependency 'rake', '~> 13.0'
   s.add_development_dependency 'rspec', '~> 3.4'
   s.add_development_dependency 'simplecov'

--- a/spec/gemfiles/rails_6_0.gemfile
+++ b/spec/gemfiles/rails_6_0.gemfile
@@ -4,8 +4,8 @@ source 'https://rubygems.org'
 
 gemspec path: '../../'
 
-gem 'activerecord', '~> 5.2.3'
-gem 'activesupport', '~> 5.2.3'
+gem 'activerecord', '~> 6.0.3'
+gem 'activesupport', '~> 6.0.3'
 
 platforms :mri, :rbx do
   # https://github.com/rails/rails/blob/v6.0.0/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb#L13

--- a/spec/gemfiles/rails_6_1.gemfile
+++ b/spec/gemfiles/rails_6_1.gemfile
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gemspec path: '../../'
+
+gem 'activerecord', '~> 6.1.1'
+gem 'activesupport', '~> 6.1.1'
+
+platforms :mri, :rbx do
+  # https://github.com/rails/rails/blob/v6.0.0/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb#L13
+  gem 'sqlite3', '~> 1.4'
+
+  # https://github.com/rails/rails/blob/v6.0.0/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L4
+  gem 'pg', '>= 0.18', '< 2.0'
+
+  # https://github.com/rails/rails/blob/v6.0.0/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb#L6
+  gem 'mysql2', '>= 0.4.4'
+end
+
+eval_gemfile '../../shared.gemfile'

--- a/spec/gemfiles/rails_7_0.gemfile
+++ b/spec/gemfiles/rails_7_0.gemfile
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gemspec path: '../../'
+
+gem 'activerecord', '~> 7.0.0'
+gem 'activesupport', '~> 7.0.0'
+
+platforms :mri, :rbx do
+  # https://github.com/rails/rails/blob/v6.0.0/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb#L13
+  gem 'sqlite3', '~> 1.4'
+
+  # https://github.com/rails/rails/blob/v6.0.0/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L4
+  gem 'pg', '>= 0.18', '< 2.0'
+
+  # https://github.com/rails/rails/blob/v6.0.0/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb#L6
+  gem 'mysql2', '>= 0.4.4'
+end
+
+eval_gemfile '../../shared.gemfile'

--- a/spec/gemfiles/rails_7_1.gemfile
+++ b/spec/gemfiles/rails_7_1.gemfile
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gemspec path: '../../'
+
+gem 'activerecord', '~> 7.1.0'
+gem 'activesupport', '~> 7.1.0'
+
+platforms :mri, :rbx do
+  gem 'sqlite3', '~> 1.4'
+  gem 'pg', '>= 0.18', '< 2.0'
+  gem 'mysql2', '>= 0.4.4'
+end
+
+eval_gemfile '../../shared.gemfile'

--- a/spec/gemfiles/rails_7_2.gemfile
+++ b/spec/gemfiles/rails_7_2.gemfile
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gemspec path: '../../'
+
+gem 'activerecord', '~> 7.2.0'
+gem 'activesupport', '~> 7.2.0'
+
+platforms :mri, :rbx do
+  gem 'sqlite3', '~> 1.4'
+  gem 'pg', '>= 0.18', '< 2.0'
+  gem 'mysql2', '>= 0.4.4'
+end
+
+eval_gemfile '../../shared.gemfile'

--- a/spec/order_query_spec.rb
+++ b/spec/order_query_spec.rb
@@ -169,6 +169,12 @@ RSpec.describe 'OrderQuery' do
           )
         end
 
+        it '.seek does not mutate the given order arguments' do
+          order = [[:priority, :desc], [:id, :asc]]
+          Issue.seek(order)
+          expect(order).to eq [[:priority, :desc], [:id, :asc]]
+        end
+
         context 'partitioned on a boolean flag' do
           before do
             create_issue(active: true)


### PR DESCRIPTION
# Description
This PR updates our fork of order_query gem with upstream changes up until 0.5.4. This is done to make it work with Rails version 7.X used in Backend application.